### PR TITLE
Disable export option

### DIFF
--- a/Parse-Dashboard/parse-dashboard-config.json
+++ b/Parse-Dashboard/parse-dashboard-config.json
@@ -7,7 +7,18 @@
       "appName": "",
       "iconName": "",
       "primaryBackgroundColor": "",
-      "secondaryBackgroundColor": ""
+      "secondaryBackgroundColor": "",
+      "deleteOptions": {
+        "class": true,
+        "columns": true,
+        "selectedRows": true,
+        "allData": true
+      },
+      "exportOptions": {
+        "schema": true,
+        "selectedRows": true,
+        "allData": true
+      }
     }
   ],
   "iconsFolder": "icons"

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -59,6 +59,9 @@ const BrowserToolbar = ({
   onCancelPendingEditRows,
   order,
 
+  enableDeleteClass,
+  enableDeleteColumns,
+  enableDeleteSelectedRows,
   enableDeleteAllRows,
   enableExportClass,
   enableSecurityDialog,
@@ -166,14 +169,18 @@ const BrowserToolbar = ({
           text={`Clone ${selectionLength <= 1 ? 'this row' : 'these rows'}`}
           onClick={onCloneSelectedRows}
         />
+        {enableDeleteSelectedRows ? <Separator /> : <noscript />}
+        {enableDeleteSelectedRows ? (
+          <MenuItem
+            disabled={selectionLength === 0}
+            text={selectionLength === 1 && !selection['*'] ? 'Delete this row' : 'Delete these rows'}
+            onClick={() => onDeleteRows(selection)}
+          />
+        ) : (
+          <noscript />
+        )}
         <Separator />
-        <MenuItem
-          disabled={selectionLength === 0}
-          text={selectionLength === 1 && !selection['*'] ? 'Delete this row' : 'Delete these rows'}
-          onClick={() => onDeleteRows(selection)}
-        />
-        <Separator />
-        {enableColumnManipulation ? (
+        {enableColumnManipulation && enableDeleteColumns ? (
           <MenuItem text="Delete a column" onClick={onRemoveColumn} />
         ) : (
           <noscript />
@@ -183,7 +190,7 @@ const BrowserToolbar = ({
         ) : (
           <noscript />
         )}
-        {enableClassManipulation ? (
+        {enableClassManipulation && enableDeleteClass ? (
           <MenuItem text="Delete this class" onClick={onDropClass} />
         ) : (
           <noscript />

--- a/src/dashboard/Data/Browser/BrowserToolbar.react.js
+++ b/src/dashboard/Data/Browser/BrowserToolbar.react.js
@@ -63,6 +63,8 @@ const BrowserToolbar = ({
   enableDeleteColumns,
   enableDeleteSelectedRows,
   enableDeleteAllRows,
+  enableExportSchema,
+  enableExportSelectedRows,
   enableExportClass,
   enableSecurityDialog,
 
@@ -87,6 +89,7 @@ const BrowserToolbar = ({
   appName,
 }) => {
   const selectionLength = Object.keys(selection).length;
+  const hasSomeExportEnabled = enableExportSchema || enableExportSelectedRows || enableExportClass;
   const isPendingEditCloneRows = editCloneRows && editCloneRows.length > 0;
   const details = [];
   if (count !== undefined) {
@@ -353,8 +356,8 @@ const BrowserToolbar = ({
           )}
         </BrowserMenu>
       )}
-      {onAddRow && <div className={styles.toolbarSeparator} />}
-      {onAddRow && (
+      {onAddRow && hasSomeExportEnabled && <div className={styles.toolbarSeparator} />}
+      {onAddRow && hasSomeExportEnabled && (
         <BrowserMenu
           title="Export"
           icon="down-solid"
@@ -362,12 +365,20 @@ const BrowserToolbar = ({
           setCurrent={setCurrent}
         >
           <MenuItem
-            disabled={!selectionLength}
+            disabled={!selectionLength || !enableExportSelectedRows}
             text={`Export ${selectionLength} selected ${selectionLength <= 1 ? 'row' : 'rows'}`}
             onClick={() => onExportSelectedRows(selection)}
           />
-          <MenuItem text={'Export all rows'} onClick={() => onExportSelectedRows({ '*': true })} />
-          <MenuItem text={'Export schema'} onClick={() => onExportSchema()} />
+          <MenuItem
+            disabled={!enableExportClass}
+            text={'Export all rows'}
+            onClick={() => onExportSelectedRows({ '*': true })}
+          />
+          <MenuItem
+            disabled={!enableExportSchema}
+            text={'Export schema'}
+            onClick={() => onExportSchema()}
+          />
         </BrowserMenu>
       )}
       {onAddRow && <div className={styles.toolbarSeparator} />}

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -622,7 +622,7 @@ export default class DataBrowser extends React.Component {
       app,
       ...other
     } = this.props;
-    const { preventSchemaEdits, applicationId } = app;
+    const { preventSchemaEdits, applicationId, deleteOptions } = app;
     return (
       <div>
         <div>
@@ -690,8 +690,13 @@ export default class DataBrowser extends React.Component {
           className={className}
           classNameForEditors={className}
           setCurrent={this.setCurrent}
+          enableDeleteClass={deleteOptions.class && !preventSchemaEdits}
+          enableDeleteColumns={deleteOptions.columns && !preventSchemaEdits}
+          enableDeleteSelectedRows={deleteOptions.selectedRows && !preventSchemaEdits}
           enableDeleteAllRows={
-            app.serverInfo.features.schemas.clearAllDataFromClass && !preventSchemaEdits
+            deleteOptions.allData &&
+            app.serverInfo.features.schemas.clearAllDataFromClass &&
+            !preventSchemaEdits
           }
           enableExportClass={app.serverInfo.features.schemas.exportClass && !preventSchemaEdits}
           enableSecurityDialog={

--- a/src/dashboard/Data/Browser/DataBrowser.react.js
+++ b/src/dashboard/Data/Browser/DataBrowser.react.js
@@ -622,7 +622,7 @@ export default class DataBrowser extends React.Component {
       app,
       ...other
     } = this.props;
-    const { preventSchemaEdits, applicationId, deleteOptions } = app;
+    const { preventSchemaEdits, applicationId, deleteOptions, exportOptions } = app;
     return (
       <div>
         <div>
@@ -698,7 +698,13 @@ export default class DataBrowser extends React.Component {
             app.serverInfo.features.schemas.clearAllDataFromClass &&
             !preventSchemaEdits
           }
-          enableExportClass={app.serverInfo.features.schemas.exportClass && !preventSchemaEdits}
+          enableExportSchema={exportOptions.schema && !preventSchemaEdits}
+          enableExportSelectedRows={exportOptions.selectedRows && !preventSchemaEdits}
+          enableExportClass={
+            exportOptions.allData &&
+            app.serverInfo.features.schemas.exportClass &&
+            !preventSchemaEdits
+          }
           enableSecurityDialog={
             app.serverInfo.features.schemas.editClassLevelPermissions &&
             !disableSecurityDialog &&

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -44,6 +44,7 @@ export default class ParseApp {
     secondaryBackgroundColor,
     supportedPushLocales,
     preventSchemaEdits,
+    deleteOptions,
     graphQLServerURL,
     columnPreference,
     scripts,
@@ -74,6 +75,12 @@ export default class ParseApp {
     this.secondaryBackgroundColor = secondaryBackgroundColor;
     this.supportedPushLocales = supportedPushLocales ? supportedPushLocales : [];
     this.preventSchemaEdits = preventSchemaEdits || false;
+    this.deleteOptions = deleteOptions || {
+      class: true,
+      columns: true,
+      selectedRows: true,
+      allData: true,
+    };
     this.graphQLServerURL = graphQLServerURL;
     this.columnPreference = columnPreference;
     this.scripts = scripts;

--- a/src/lib/ParseApp.js
+++ b/src/lib/ParseApp.js
@@ -45,6 +45,7 @@ export default class ParseApp {
     supportedPushLocales,
     preventSchemaEdits,
     deleteOptions,
+    exportOptions,
     graphQLServerURL,
     columnPreference,
     scripts,
@@ -78,6 +79,11 @@ export default class ParseApp {
     this.deleteOptions = deleteOptions || {
       class: true,
       columns: true,
+      selectedRows: true,
+      allData: true,
+    };
+    this.exportOptions = exportOptions || {
+      schema: true,
       selectedRows: true,
       allData: true,
     };


### PR DESCRIPTION
# Changes
- Added new property `deleteOptions` for toggling delete operations on data browser toolbar;
- Added new property `exportOptions` for toggling export operations on data browser toolbar.


These new options can be set directly on `parse-dashboard-config.json` configuration file as follows:
``` json
{
  "apps": [
    {
      "serverURL": "http://localhost:1337/parse",
      "appId": "hello",
      "masterKey": "world",
      "appName": "",
      "iconName": "",
      "primaryBackgroundColor": "",
      "secondaryBackgroundColor": "",
      "deleteOptions": {
        "class": true,
        "columns": true,
        "selectedRows": true,
        "allData": true
      },
      "exportOptions": {
        "schema": true,
        "selectedRows": true,
        "allData": true
      }
    }
  ],
  "iconsFolder": "icons"
}

```

# Screenshots
## Export all rows and export selected rows disabled
> ![image](https://github.com/user-attachments/assets/fbf992c7-b49d-4ed1-b259-8bcfaaa79283)

## All delete operations disabled
>![image](https://github.com/user-attachments/assets/eac1f719-ecb3-44fc-ac75-5dc94396965f)

## Only deleted *selected* rows enabled
>![image](https://github.com/user-attachments/assets/6aed57d3-248d-4e2e-98e5-6d3d1b7233a3)


