### PR TITLE
chore: add stale PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: 'This PR has been inactive for 30 days and has been marked as stale. It will be closed in 7 days unless there is new activity.'
+          close-pr-message: 'This PR was closed due to 37 days of inactivity.'
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: 'stale'
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
Auto-closes stale PRs after 30 days of inactivity, with a 7-day notice before closing.